### PR TITLE
feat: remove Sendable

### DIFF
--- a/src/IOError.flix
+++ b/src/IOError.flix
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-pub enum IOError with Eq, Order, ToString, Hash, Sendable {
+pub enum IOError with Eq, Order, ToString, Hash {
     case Generic(String)
 }
 


### PR DESCRIPTION
After https://github.com/flix/flix/pull/9556 there is no Sendable trait or `Channel.unsafeSend`. You can just send anything. This PR fixes that